### PR TITLE
Added project_id key format

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ If you want your package to update itself from **Modrinth**, you need to add the
     },
     "remote": {
       "game_version": "1.20.1", // game version
-      "modrinth_project_id": "better-leaves", // your project identifier
+      "project_id": "better-leaves", // your project identifier
       "type": "modrinth"
     },
     "formatVersion": 1

--- a/common/src/main/java/com/adamcalculator/dynamicpack/pack/ModrinthRemote.java
+++ b/common/src/main/java/com/adamcalculator/dynamicpack/pack/ModrinthRemote.java
@@ -27,7 +27,8 @@ public class ModrinthRemote extends Remote {
     public void init(Pack parent, JSONObject json, JSONObject current) {
         this.parent = parent;
         this.cachedCurrentJson = current;
-        this.projectId = json.getString("modrinth_project_id");
+        this.projectId = json.opt("project_id").toString();
+        if (this.projectId == null) this.projectId = json.getString("modrinth_project_id");
         var ver = json.optString("game_version", "no_specify");
         this.usesCurrentGameVersion = ver.equalsIgnoreCase("current");
         this.noSpecifyGameVersion = ver.equalsIgnoreCase("no_specify");

--- a/common/src/main/java/com/adamcalculator/dynamicpack/pack/ModrinthRemote.java
+++ b/common/src/main/java/com/adamcalculator/dynamicpack/pack/ModrinthRemote.java
@@ -27,8 +27,8 @@ public class ModrinthRemote extends Remote {
     public void init(Pack parent, JSONObject json, JSONObject current) {
         this.parent = parent;
         this.cachedCurrentJson = current;
-        this.projectId = json.opt("project_id").toString();
-        if (this.projectId == null) this.projectId = json.getString("modrinth_project_id");
+        this.projectId = json.optString("project_id");
+        if (this.projectId.isEmpty()) this.projectId = json.getString("modrinth_project_id");
         var ver = json.optString("game_version", "no_specify");
         this.usesCurrentGameVersion = ver.equalsIgnoreCase("current");
         this.noSpecifyGameVersion = ver.equalsIgnoreCase("no_specify");


### PR DESCRIPTION
Added a new key format for json project_id without deleting the old one modrinth_project_id. It looks for project_id in json in prioritize and if it does not find it then it looks for modrinth_project_id for old json format compatibility. It was made with purpose for future compatibility with new remote types as curseforge or something else.